### PR TITLE
Update old syntax names 't' and 'pass_mark' to their respective new and enforced names for compatibility with latest AAI versions

### DIFF
--- a/example_configs/config.yaml
+++ b/example_configs/config.yaml
@@ -1,8 +1,8 @@
 !ArenaConfig
 arenas:
   0: !Arena
-    pass_mark: 0
-    t: 1000
+    passMark: 0
+    timeLimit: 1000
     items:
     - !Item
       name: Wall

--- a/example_configs/config_broken.yaml
+++ b/example_configs/config_broken.yaml
@@ -1,8 +1,8 @@
 !ArenaConfig
 arenas:
   0: !Arena
-    pass_mark: 0
-    t: 1000
+    passMark: 0
+    timeLimit: 1000
     items:
     - !Item
       name: Wall

--- a/example_configs/config_no_colours.yaml
+++ b/example_configs/config_no_colours.yaml
@@ -1,8 +1,8 @@
 !ArenaConfig
 arenas:
   0: !Arena
-    pass_mark: 0
-    t: 1000
+    passMark: 0
+    timeLimit: 1000
     items:
     - !Item
       name: Wall

--- a/example_configs/config_short.yaml
+++ b/example_configs/config_short.yaml
@@ -1,8 +1,8 @@
 !ArenaConfig
 arenas:
   0: !Arena
-    pass_mark: 0
-    t: 1000
+    passMark: 0
+    timeLimit: 1000
     items:
     - !Item
       name: Wall

--- a/src/app/callback_registrar.py
+++ b/src/app/callback_registrar.py
@@ -242,11 +242,11 @@ class CallbackRegistrar:
             """
             create_directory_if_not_exists(os.path.dirname(new_config_path))
 
-            pass_mark = self.current_arena.pass_mark
-            t = self.current_arena.t
+            passMark = self.current_arena.passMark
+            timeLimit = self.current_arena.timeLimit
             arena = Arena(
-                pass_mark=pass_mark,
-                t=t,
+                passMark=passMark,
+                timeLimit=timeLimit,
                 physical_items=self.cuboids,
                 overlapping_items=[""],
             )
@@ -386,8 +386,8 @@ class CallbackRegistrar:
                 time_limit (str): The arena's new time_limit parameter.
             """
             if num_set_config_params_button_click > 0:
-                self.current_arena.t = int(time_limit)
-                self.current_arena.pass_mark = int(pass_mark)
+                self.current_arena.timeLimit = int(time_limit)
+                self.current_arena.passMark = int(pass_mark)
 
     def _update_pre_plotting_attributes(
         self, cuboids: List[RectangularCuboid], item_ix: int, xz_rotation: float

--- a/src/processing/dumper.py
+++ b/src/processing/dumper.py
@@ -55,13 +55,13 @@ class Dumper:
         return result
 
     def _get_arena_settings_str(self, ix: int, level: int) -> str:
-        """Gets the string representation of all the arena config attributes other than items (pass_mark, t)."""
-        pass_mark = self.arenas[ix].pass_mark
-        t = self.arenas[ix].t
+        """Gets the string representation of all the arena config attributes other than items (passMark, timeLimit)."""
+        passMark = self.arenas[ix].passMark
+        timeLimit = self.arenas[ix].timeLimit
         return (
-            self._indent(f"pass_mark: {pass_mark}", level)
+            self._indent(f"passMark: {passMark}", level)
             + "\n"
-            + self._indent(f"t: {t}", level)
+            + self._indent(f"timeLimit: {timeLimit}", level)
         )
 
     def _get_arena_items_str(self, ix: int, level: int) -> str:
@@ -164,8 +164,8 @@ def dumper_example() -> None:
         deg_rotation: float
 
     arena1 = {
-        "pass_mark": 0,
-        "t": 1000,
+        "passMark": 0,
+        "timeLimit": 1000,
         "items": [
             DummyCuboid(
                 name="Wall 0",

--- a/src/processing/preprocessor.py
+++ b/src/processing/preprocessor.py
@@ -21,7 +21,7 @@ class Preprocessor:
     """
 
     DEFAULT_PASS_MARK = 0
-    DEFAULT_T = 1000
+    DEFAULT_TIMELIMIT = 1000
 
     def __init__(
         self, default_item_parameters: Dict, all_aai_item_names: List[str]
@@ -31,8 +31,8 @@ class Preprocessor:
 
     def create_default_arenas_list(self) -> List[Arena]:
         default_arena = Arena(
-            pass_mark=self.DEFAULT_PASS_MARK,
-            t=self.DEFAULT_T,
+            passMark=self.DEFAULT_PASS_MARK,
+            timeLimit=self.DEFAULT_TIMELIMIT,
             physical_items=[],
             overlapping_items=[],
         )
@@ -45,12 +45,12 @@ class Preprocessor:
 
         for arena_ix in list(raw_arenas.keys()):
             raw_arena = raw_arenas[arena_ix]
-            pass_mark = raw_arena["pass_mark"]
-            t = raw_arena["t"]
+            passMark = raw_arena["passMark"]
+            timeLimit = raw_arena["timeLimit"]
             raw_physical_items = raw_arena["items"]
             physical_items = self._create_rectangular_cuboid_list(raw_physical_items)
             overlapping_items = []
-            arena = Arena(pass_mark, t, physical_items, overlapping_items)
+            arena = Arena(passMark, timeLimit, physical_items, overlapping_items)
             preprocessed_arenas_list += [arena]
 
         return preprocessed_arenas_list

--- a/src/structures/arena.py
+++ b/src/structures/arena.py
@@ -8,12 +8,12 @@ class Arena:
 
     def __init__(
         self,
-        pass_mark: float,
-        t: float,
+        passMark: float,
+        timeLimit: float,
         physical_items: List[RectangularCuboid],
         overlapping_items: List[str],
     ) -> None:
-        self.pass_mark = pass_mark
-        self.t = t
+        self.passMark = passMark
+        self.timeLimit = timeLimit
         self.physical_items = physical_items
         self.overlapping_items = overlapping_items


### PR DESCRIPTION
### Description:
Simple PR to change the occurrences of the old syntax names to use their new ones:

- '`t'` becomes '`timeLimit`',
- '`pass_mark`' becomes '`passMark`'

Some users within the team had trouble running the latest version of AAI with config assistant (due to these syntax mismatches between the applications). This PR addresses these problems. 

### Changes:
1. Updated all occurrences of the old syntax for t and pass_mark in 19789d68c510d117a156bbe72b2f2d265b189f93,
2. Updated the example configs to use the new syntax names b831bf42cd7a47e973a5e35444ca0d9828ac0fd4.

### DONE:
1. Ran the application and everything works as expected after changes
2. Passed all tests in the repo